### PR TITLE
feat(aws): AWS S3 연동을 위한 서비스 및 컨트롤러 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	// swagger를 통한 API 문서화
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+	// aws s3를 통한 파일 저장
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/aischool/goodswap/GoodswapApplication.java
+++ b/src/main/java/com/aischool/goodswap/GoodswapApplication.java
@@ -3,8 +3,10 @@ package com.aischool.goodswap;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableRetry
+@EnableScheduling
 @SpringBootApplication
 public class GoodswapApplication {
 

--- a/src/main/java/com/aischool/goodswap/config/S3Config.java
+++ b/src/main/java/com/aischool/goodswap/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.aischool.goodswap.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+  @Value("${S3_ACCESS_KEY}")
+  private String accessKey;
+  @Value("${S3_SECRET_KEY}")
+  private String secretKey;
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3 amazonS3Client() {  // Amazon S3 클라이언트 객체를 생성하고 구성하는 빈을 정의
+    // AWS에 접근하기 위한 accessKey와 secretKey를 사용하여 생성,  다형성을 활용해 객체를 생성
+    BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+    //클라이언트 객체를 구성
+    return AmazonS3ClientBuilder
+      .standard()  // standard() 메서드를 호출하여 기본 빌더를 생성한 뒤, 자격 증명 객체와 region을 지정
+      .withCredentials(new AWSStaticCredentialsProvider(credentials))
+      .withRegion(region)
+      .build();
+  }
+}

--- a/src/main/java/com/aischool/goodswap/config/SchedulerConfiguration.java
+++ b/src/main/java/com/aischool/goodswap/config/SchedulerConfiguration.java
@@ -1,0 +1,22 @@
+package com.aischool.goodswap.config;
+
+import com.aischool.goodswap.service.PostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SchedulerConfiguration {
+
+  @Autowired
+  private PostService postService;
+
+  @Scheduled(cron = "0 0 0/6 * * ?")
+  public void run() {
+    postService.cleanUpOrphanFile();
+  }
+}

--- a/src/main/java/com/aischool/goodswap/controller/AmazonS3Controller.java
+++ b/src/main/java/com/aischool/goodswap/controller/AmazonS3Controller.java
@@ -1,0 +1,33 @@
+package com.aischool.goodswap.controller;
+
+import com.aischool.goodswap.service.AwsS3Service;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/file")
+public class AmazonS3Controller {
+
+  private final AwsS3Service awsS3Service;
+
+  @PostMapping("/upload")
+  public ResponseEntity<String> uploadFile(MultipartFile multipartFile){
+    return ResponseEntity.ok(awsS3Service.uploadSingleFile(multipartFile));
+  }
+
+  @DeleteMapping("/delete/{fileId}")
+  public ResponseEntity<String> deleteFile(@PathVariable Long fileId) throws IOException {
+    awsS3Service.deleteFile(fileId);
+    return ResponseEntity.accepted().build();
+  } 
+  // 게시글의 회원id를 받아서 권한이 있는지 확인하기
+
+}

--- a/src/main/java/com/aischool/goodswap/domain/File.java
+++ b/src/main/java/com/aischool/goodswap/domain/File.java
@@ -1,16 +1,12 @@
 package com.aischool.goodswap.domain;
 
 import java.time.LocalDateTime;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.CreationTimestamp;
 
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 
@@ -23,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"post"})
+@ToString
 @Table(name = "tb_file")
 public class File {
 
@@ -32,21 +28,23 @@ public class File {
     @Column(name = "file_idx")
     private Long id;
 
-    @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    @JoinColumn(name = "post_idx", nullable = false)
-    private Post post;
+    @Column(name = "post_idx")
+    private Long postIdx;
 
     @Column(name = "file_url", nullable = false, length = 1500)
     private String fileUrl;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
     
     @CreationTimestamp
     @Column(name = "uploaded_at", updatable = false)
     private LocalDateTime uploadedAt = LocalDateTime.now();
 
     @Builder
-    public File(Post post, String fileUrl) {
-        this.post = post;
+    public File(Long postIdx, String fileUrl, String fileName) {
+        this.postIdx = postIdx;
         this.fileUrl = fileUrl;
+        this.fileName = fileName;
     }
 }

--- a/src/main/java/com/aischool/goodswap/repository/CardRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/CardRepository.java
@@ -1,4 +1,4 @@
-package com.aischool.goodswap.repository.payment;
+package com.aischool.goodswap.repository;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/aischool/goodswap/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/DeliveryAddressRepository.java
@@ -1,4 +1,4 @@
-package com.aischool.goodswap.repository.payment;
+package com.aischool.goodswap.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/aischool/goodswap/repository/FileRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/FileRepository.java
@@ -1,0 +1,12 @@
+package com.aischool.goodswap.repository;
+
+import com.aischool.goodswap.domain.File;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FileRepository extends JpaRepository<File, Long> {
+  List<File> findByPostIdxIsNullAndUploadedAtBefore(LocalDateTime uploadedAt);
+}

--- a/src/main/java/com/aischool/goodswap/repository/GoodsRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/GoodsRepository.java
@@ -1,4 +1,4 @@
-    package com.aischool.goodswap.repository.payment;
+    package com.aischool.goodswap.repository;
 
     import jakarta.persistence.LockModeType;
     import jakarta.transaction.Transactional;

--- a/src/main/java/com/aischool/goodswap/repository/OrderRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/OrderRepository.java
@@ -1,4 +1,4 @@
-package com.aischool.goodswap.repository.payment;
+package com.aischool.goodswap.repository;
 
 import com.aischool.goodswap.domain.Order;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/aischool/goodswap/repository/PointRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/PointRepository.java
@@ -1,4 +1,4 @@
-package com.aischool.goodswap.repository.payment;
+package com.aischool.goodswap.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/aischool/goodswap/repository/UserRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package com.aischool.goodswap.repository.payment;
+package com.aischool.goodswap.repository;
 
 import com.aischool.goodswap.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/aischool/goodswap/repository/user/UserRepository.java
+++ b/src/main/java/com/aischool/goodswap/repository/user/UserRepository.java
@@ -1,5 +1,0 @@
-package com.aischool.goodswap.repository.user;
-
-public class UserRepository {
-    
-}

--- a/src/main/java/com/aischool/goodswap/service/AsyncPaymentService.java
+++ b/src/main/java/com/aischool/goodswap/service/AsyncPaymentService.java
@@ -3,10 +3,10 @@ package com.aischool.goodswap.service;
 import com.aischool.goodswap.domain.CreditCard;
 import com.aischool.goodswap.domain.DeliveryAddress;
 import com.aischool.goodswap.domain.Goods;
-import com.aischool.goodswap.repository.payment.CardRepository;
-import com.aischool.goodswap.repository.payment.DeliveryAddressRepository;
-import com.aischool.goodswap.repository.payment.GoodsRepository;
-import com.aischool.goodswap.repository.payment.PointRepository;
+import com.aischool.goodswap.repository.CardRepository;
+import com.aischool.goodswap.repository.DeliveryAddressRepository;
+import com.aischool.goodswap.repository.GoodsRepository;
+import com.aischool.goodswap.repository.PointRepository;
 
 import com.aischool.goodswap.security.AESUtil;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/aischool/goodswap/service/AwsS3Service.java
+++ b/src/main/java/com/aischool/goodswap/service/AwsS3Service.java
@@ -1,0 +1,103 @@
+package com.aischool.goodswap.service;
+
+import com.aischool.goodswap.domain.File;
+import com.aischool.goodswap.repository.FileRepository;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Autowired
+  private AmazonS3 amazonS3;
+  @Autowired
+  private FileRepository fileRepository;
+
+  // 단일 파일을 업로드하고, 업로드된 파일의 URL과 파일 이름을 반환하는 메서드
+  public String uploadSingleFile(MultipartFile multipartFile) {
+    String filename = createFileName(multipartFile.getOriginalFilename());
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(multipartFile.getSize());
+    objectMetadata.setContentType(multipartFile.getContentType());
+
+    try (InputStream inputStream = multipartFile.getInputStream()) {
+      amazonS3.putObject(new PutObjectRequest(bucket, filename, inputStream, objectMetadata)
+        .withCannedAcl(CannedAccessControlList.PublicRead));
+    } catch (IOException e) {
+      throw new IllegalStateException("파일 업로드 실패");
+    }
+    File newFile = File.builder()
+      .fileUrl(amazonS3.getUrl(bucket, filename).toString())
+      .fileName(filename)
+      .build();
+
+    fileRepository.save(newFile);
+
+    return newFile.getFileUrl();
+  }
+
+  // 다중 파일을 업로드하고, 각 파일의 결과를 담은 리스트를 반환하는 메서드
+  // 지금은 파일을 하나씩 보낼거같아서 일단 보류
+  public List<String> uploadFiles(List<MultipartFile> multipartFiles) {
+    return multipartFiles.stream()
+      .map(this::uploadSingleFile) // 각 파일에 대해 uploadSingleFile 메서드 호출
+      .toList(); // 각 결과를 List로 수집
+  }
+
+
+
+  // 파일명을 난수화하기 위해 UUID 를 활용하여 난수를 돌린다.
+  public String createFileName(String fileName){
+    return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+  }
+
+  //  "."의 존재 유무만 판단
+  private String getFileExtension(String fileName){
+    try{
+      return fileName.substring(fileName.lastIndexOf("."));
+    } catch (StringIndexOutOfBoundsException e){
+      throw new IllegalStateException("잘못된 형식의 파일(" + fileName + ") 입니다.");
+    }
+  }
+
+
+  public void deleteFile(Long fileId) throws IOException {
+
+    File file = fileRepository.findById(fileId)
+      .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다."));
+
+    String fileName = file.getFileName();
+    boolean isObjectExist = amazonS3.doesObjectExist(bucket, fileName);
+    if (isObjectExist) {
+      log.info("저장정보 확인");
+      try{
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+      }catch (SdkClientException e){
+        throw new IOException("Error deleting file from S3",e);
+      }
+    } else {
+      log.info("존재하지 않음");
+    }
+  }
+}

--- a/src/main/java/com/aischool/goodswap/service/PaymentService.java
+++ b/src/main/java/com/aischool/goodswap/service/PaymentService.java
@@ -51,7 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
 
     // 결제 사전정보 전송
     @Transactional(readOnly = true)
-    @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
+    @Retryable(value = Exception.class, backoff = @Backoff(delay = 1000))
     public CompletableFuture<PaymentInfoResponseDTO> getPaymentInfo(String user, Long goodsId) {
         // 비동기 메서드 호출
         // 각각의 정보를 비동기 방식으로 받아옴을 명시
@@ -185,7 +185,7 @@ import org.springframework.transaction.annotation.Transactional;
 
     // 회원 이메일을 기준으로 모든 카드정보 가져옴
     @Transactional(readOnly = true)
-    @Retryable(value = Exception.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
+    @Retryable(value = Exception.class, backoff = @Backoff(delay = 1000))
     public List<Map<String, String>> getCardInfo(String userEmail) {
         List<CreditCard> cards = cardRepository.findAllByUser_UserEmail(userEmail);
         List<Map<String, String>> cardInfoList = new ArrayList<>();

--- a/src/main/java/com/aischool/goodswap/service/PaymentService.java
+++ b/src/main/java/com/aischool/goodswap/service/PaymentService.java
@@ -6,8 +6,13 @@ import com.aischool.goodswap.DTO.PaymentInfoRequestDTO;
 import com.aischool.goodswap.DTO.PaymentInfoResponseDTO;
 import com.aischool.goodswap.domain.*;
 import com.aischool.goodswap.exception.EncryptionException;
+import com.aischool.goodswap.repository.CardRepository;
+import com.aischool.goodswap.repository.DeliveryAddressRepository;
+import com.aischool.goodswap.repository.GoodsRepository;
+import com.aischool.goodswap.repository.OrderRepository;
+import com.aischool.goodswap.repository.PointRepository;
+import com.aischool.goodswap.repository.UserRepository;
 import com.aischool.goodswap.security.AESUtil;
-import com.aischool.goodswap.repository.payment.*;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/com/aischool/goodswap/service/PostService.java
+++ b/src/main/java/com/aischool/goodswap/service/PostService.java
@@ -1,0 +1,45 @@
+package com.aischool.goodswap.service;
+
+
+import com.aischool.goodswap.domain.File;
+import com.aischool.goodswap.repository.FileRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+  @Autowired
+  private FileRepository fileRepository;
+  @Autowired
+  private AwsS3Service awsS3Service;
+
+  public void cleanUpOrphanFile() {
+// 현재로부터 24시간 전 시간 계산
+    LocalDateTime thresholdTime = LocalDateTime.now().minusHours(24);
+
+    // post_idx가 null이고, 생성된 지 24시간이 지난 파일들을 조회
+    List<File> orphanFiles = fileRepository.findByPostIdxIsNullAndUploadedAtBefore(thresholdTime);
+
+    for (File orphanFile : orphanFiles) {
+      Long fileId = orphanFile.getId();
+      try {
+        // S3에서 파일 삭제
+        awsS3Service.deleteFile(fileId);
+
+        // DB에서도 해당 파일 삭제
+        fileRepository.deleteById(fileId);
+
+        log.info("Deleted orphan file with ID: {} from S3 and database.", fileId);
+      } catch (Exception e) {
+        log.error("Failed to delete orphan file with ID: {} due to {}", fileId, e.getMessage());
+      }
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
 
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
@@ -33,6 +37,19 @@ springdoc:
 
   paths-to-match:
     - /api/** # swagger-ui에 표시할 api의 엔드포인트 패턴
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    s3:
+      bucket: goodswap-s3-bucket
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
 
 server:
   address: 0.0.0.0


### PR DESCRIPTION
- AWS S3에 파일을 업로드하고 삭제하는 기능을 위한 `AwsS3Service`, `AmazonS3Controller` 추가
- `S3Config` 클래스에서 AWS 자격증명 및 리전 설정을 통해 S3 클라이언트 구성
- `FileRepository` 추가하여 파일 관련 데이터를 DB에 저장
- 이미지 파일 업로드 및 삭제 API 구현
- `application.yml`에 AWS S3 관련 설정 추가
- 6개의 repository 파일을 `repository.payment` 패키지에서 `repository` 패키지로 이동하여 패키지 구조를 단순화시킴.
- Retryable적용시 default값인 maxAttempts = 3을 명시해두었으나 제거함